### PR TITLE
Use iostream - add DTCM sections to csf flash in linker

### DIFF
--- a/apps/blinky/src/main.cpp
+++ b/apps/blinky/src/main.cpp
@@ -1,13 +1,18 @@
+#include <iostream>
+
 #include <Arduino.h>
 
 int main()
 {
-	pinMode(13, OUTPUT);
-	while (true)
-	{
-		digitalWriteFast(13, HIGH);
-		delay(1000);
-		digitalWriteFast(13, LOW);
-		delay(200);
-	}
+    pinMode(13, OUTPUT);
+
+    size_t counter = 0UL;
+    while (true)
+    {
+        digitalWriteFast(13, HIGH);
+        delay(1000);
+        digitalWriteFast(13, LOW);
+        delay(200);
+        std::cout << "Hello world" << ++counter << '\n';
+    }
 }

--- a/common/core/write.cpp
+++ b/common/core/write.cpp
@@ -1,0 +1,4 @@
+extern "C" int _write(int fd [[gnu::unused]], char *ptr, int len)
+{
+    return Serial.write(ptr, len);
+}

--- a/common/extlib/linker/imxrt1062.ld
+++ b/common/extlib/linker/imxrt1062.ld
@@ -73,7 +73,7 @@ SECTIONS
 		FILL(0xFF)
 		. = ALIGN(1024);
 		KEEP(*(.csf))
-	} > FLASH
+	} > DTCM AT> FLASH
 
 	_stext = ADDR(.text.itcm);
 	_etext = ADDR(.text.itcm) + SIZEOF(.text.itcm) + SIZEOF(.ARM.exidx);

--- a/common/extlib/linker/imxrt1062_mm.ld
+++ b/common/extlib/linker/imxrt1062_mm.ld
@@ -73,7 +73,7 @@ SECTIONS
 		FILL(0xFF)
 		. = ALIGN(1024);
 		KEEP(*(.csf))
-	} > FLASH
+	} > DTCM AT> FLASH
 
 	_stext = ADDR(.text.itcm);
 	_etext = ADDR(.text.itcm) + SIZEOF(.text.itcm) + SIZEOF(.ARM.exidx);

--- a/common/extlib/linker/imxrt1062_t41.ld
+++ b/common/extlib/linker/imxrt1062_t41.ld
@@ -79,7 +79,7 @@ SECTIONS
 		FILL(0xFF)
 		. = ALIGN(1024);
 		KEEP(*(.csf))
-	} > FLASH
+	} > DTCM AT> FLASH
 
 	_stext = ADDR(.text.itcm);
 	_etext = ADDR(.text.itcm) + SIZEOF(.text.itcm) + SIZEOF(.ARM.exidx);


### PR DESCRIPTION
See [this thread](https://forum.pjrc.com/threads/67252-Teensyduino-1-54-Beta-9) for mention of the linker issues. Resolved by capturing the exception sections and placing them into the csf flash section.